### PR TITLE
Update zgen installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ handle cloning the plugin for you the next time you start zsh. You can also add 
 ### Zgen
 
 ```zsh
-zgen load zdharma-continuum/history-search-multi-word
+zgen load zdharma-continuum/history-search-multi-word . main
 ```
 
 to your .zshrc file in the same place you're doing your other `zgen load` calls in.


### PR DESCRIPTION
## Description
By default, zgen loads plugins from the master repository. However, when attempting to load the history-search-multi-word plugin, an error is encountered due to its default branch being named "main" instead of "master". To address this issue, you can add the branch name to the command, with the period before the branch name indicating the location within the repository that zgen should search for the plugin. In this case, the period represents the root directory.

## Related Issue(s)

<!--- If it fixes an open issue, add a link the issue -->

## Motivation and Context <!--- What problem does it solve? -->

## Usage examples

```zsh

```

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [ ] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
